### PR TITLE
Make ffmpeg dependency recommended

### DIFF
--- a/HomebrewFormula/survex.rb
+++ b/HomebrewFormula/survex.rb
@@ -7,7 +7,7 @@ class Survex < Formula
 
   depends_on "wxwidgets"
   depends_on "proj"
-  depends_on "ffmpeg"
+  depends_on "ffmpeg" => :recommended
 
   depends_on "gettext" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
From Survex's INSTALL file: "... Optionally, FFMPEG is used if available to implement Aven's movie export feature.  If not available this feature is disabled."
So instead of forcing ffmpeg install (with a lot of other dependencies) to everyone we can mark this dependency as "recommended" to allow users to exclude it with '--without-ffmpeg' parameter - see https://docs.brew.sh/Formula-Cookbook